### PR TITLE
Remove unused broccoli-stew dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 /* jshint node: true */
 'use strict';
 var path = require('path');
-var find = require('broccoli-stew').find;
-var log = require('broccoli-stew').log;
 
 module.exports = {
   name: 'ember-highlight-js',

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
     "broccoli-ember-hbs-template-compiler": "^1.6.1",
-    "broccoli-stew": "^0.1.7",
     "ember-cli": "0.1.12",
     "ember-cli-6to5": "^3.0.0",
     "ember-cli-app-version": "0.3.1",


### PR DESCRIPTION
The find and log variables were required but never used. Consequentally because broccoli-stew was in devDependencies it was never pulled into projects that add this addon. This cause a crash attempting to require a package that npm never installed.

Fixes issue #6