### PR TITLE
Updated each helper notation

### DIFF
--- a/app/templates/components/highlight-js.hbs
+++ b/app/templates/components/highlight-js.hbs
@@ -1,6 +1,6 @@
 {{#if hasLineNumbers}}
   <ul class='ember-highlight-line-numbers'>
-    {{#each number in lineNumbers}}
+    {{#each lineNumbers as |number|}}
       <li>{{unbound number}}</li>
     {{/each}}
   </ul>


### PR DESCRIPTION
Using {{#each number in lineNumbers}} is no longer supported in Ember 2.0+, please use {{#each lineNumbers as |number|}}