### PR TITLE
Make 'initHighlighting' functions callable

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,9 @@ module.exports = {
           'default',
           'highlight',
           'highlightAuto',
-          'highlightBlock'
+          'highlightBlock',
+          'initHighlighting',
+          'initHighlightingOnLoad'
         ]
       }
     });

--- a/vendor/highlight.js/index.js
+++ b/vendor/highlight.js/index.js
@@ -9856,7 +9856,9 @@ define('highlight.js', [], function(){
     default: highlight,
     highlight: highlight.highlight,
     highlightAuto: highlight.highlightAuto,
-    highlightBlock: highlight.highlightBlock
+    highlightBlock: highlight.highlightBlock,
+    initHighlighting: highlight.initHighlighting,
+    initHighlightingOnLoad: highlight.initHighlightingOnLoad,
   };
 });
 


### PR DESCRIPTION
Attempt to resolve: #13 

---

Sorry if this doesn't do anything:
- I have no clue what an `index.js` file does in the root directory of an addon
- It's just the only other place `highlightAuto` popped up
